### PR TITLE
Remove non dangerous query strings

### DIFF
--- a/handlers/login.go
+++ b/handlers/login.go
@@ -112,7 +112,7 @@ var (
 	errInvalidURL = errors.New("requested destination URL appears to be invalid")
 	errURLNotHTTP = errors.New("requested destination URL is not a valid URL (does not begin with 'http://' or 'https://')")
 	errDangerQS   = errors.New("requested destination URL has a dangerous query string")
-	badStrings    = []string{"http://", "https://", "data:", "ftp://", "ftps://", "//", "javascript:"}
+	badStrings    = []string{"data:", "ftp://", "ftps://", "javascript:"}
 	reAmpSemi     = regexp.MustCompile("[&;]")
 )
 


### PR DESCRIPTION
Part of https://apiiro.atlassian.net/browse/LIM-18562

Some of our urls has query string values that start with https:// when filtering on server url since thats key for server url